### PR TITLE
package malkusch/php-mock moved to php-mock/php-mock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "fwolf/phpunit-wrapper": "1.*",
-        "malkusch/php-mock": "0.*",
+        "php-mock/php-mock": "^0.7",
         "mikey179/vfsStream": "1.*",
         "phpunit/phpunit": "4.*"
     },

--- a/tests/FwlibTest/Aide/FunctionMockWrapperTrait.php
+++ b/tests/FwlibTest/Aide/FunctionMockWrapperTrait.php
@@ -1,8 +1,8 @@
 <?php
 namespace FwlibTest\Aide;
 
-use malkusch\phpmock\Mock;
-use malkusch\phpmock\MockBuilder;
+use phpmock\Mock;
+use phpmock\MockBuilder;
 
 /**
  * Wrapper of phpmock Mock


### PR DESCRIPTION
Hi,
I moved malkusch/php-mock to [php-mock/php-mock](https://github.com/php-mock/php-mock).
